### PR TITLE
Update to use yaml config as it's easier to read with comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,66 +13,61 @@ VOLTTRON historian agent that stores data into a SQLite database
 
 1. Create and activate a virtual environment.
 
-```shell
-python -m venv env
-source env/bin/activate
-```
+   ```shell
+    python -m venv env
+    source env/bin/activate
+    ```
 
 2. Installing volttron-sqlite-historian requires a running volttron instance.
 
-```shell
-pip install volttron
+    ```shell
+    pip install volttron
+    
+    # Start platform with output going to volttron.log
+    volttron -vv -l volttron.log &
+    ```
 
-# Start platform with output going to volttron.log
-volttron -vv -l volttron.log &
-```
+3. Create a agent configuration file 
+   SQLite historian supports two parameters
+    
+    - connection -  This is a mandatory parameter with type indicating the type of sql historian (i.e. sqlite) and params 
+                    containing the path the database file.
+    
+    - tables_def - Optional parameter to provide custom table names for topics, data, and metadata.
+    
+    The configuration can be in a json or yaml formatted file.
 
-3. Create a agent configuration file
+    Yaml Format:
 
-SQLite historian supports two parameters
-
-connection - This is a mandatory parameter with type indicating the type of sql historian (i.e. sqlite) and params 
-             containing the path the database file.
-
-tables_def - Optional parameter to provide custom table names for topics, data, and metadata.
-
-Example:
-
-JSON format :
-
-    {
-        "connection": {
-            # type should be sqlite
-            "type": "sqlite",
-            "params": {
-                "database": "data/historian.sqlite",
-            }
-        }
-        "tables_def":  {
-            # prefix for data, topics, and (in version < 4.0.0 metadata tables)
-            # default is ""
-            "table_prefix": "",
-            # table name for time series data. default "data"
-            "data_table": "data",
-            # table name for list of topics. default "topics"
-            "topics_table": "topics",
-            # table name mapping topic to metadata. default "meta"
-            # In sqlhistorian version >= 4.0.0 metadata is stored in topics table
-            "meta_table": "meta"
-        }
-    }
-
+    ```yaml
+    connection:
+      # type should be sqlite
+      type: sqlite
+      params:
+        # Relative to the agents data directory
+        database: "data/historian.sqlite"
+    
+      tables_def:
+        # prefix for data, topics, and (in version < 4.0.0 metadata tables)
+        # default is ""
+        table_prefix: ""
+        # table name for time series data. default "data"
+        data_table: data
+        # table name for list of topics. default "topics"
+        topics_table: topics
+    ```
+    
 4. Install and start the volttron-sqlite-historian.
 
-```shell
-vctl install volttron-sqlite-historian --agent-config <path to configuration> --start
-```
+    ```shell
+    vctl install volttron-sqlite-historian --agent-config <path to configuration> --start
+    ```
 
 5. View the status of the installed agent
 
-```shell
-vctl status
-```
+    ```shell
+    vctl status
+    ```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![ci](https://github.com/VOLTTRON/volttron-sqlite-historian/workflows/ci/badge.svg)](https://github.com/VOLTTRON/volttron-sqlite-historian/actions?query=workflow%3Aci)
+[![Run tests](https://github.com/eclipse-volttron/volttron-sqlite-historian/actions/workflows/run-tests.yml/badge.svg)](https://github.com/eclipse-volttron/volttron-sqlite-historian/actions/workflows/run-tests.yml)
 [![pypi version](https://img.shields.io/pypi/v/volttron-sqlite-historian.svg)](https://pypi.org/project/volttron-sqlite-historian/)
 
 VOLTTRON historian agent that stores data into a SQLite database


### PR DESCRIPTION
Formats the readme to have blocks correctly formatted.
Used yaml as the  config instead of json.